### PR TITLE
fix(docs): add where to configure the bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ OPENAI_MODEL=gpt-4o # or any other OpenAI model that supports tools
 
 Note: reactivate the environment if needed to use the keys in `.env`: `source .venv/bin/activate`
 
-Then configure the bridge:
+Then configure the bridge in [src/mcp_llm_bridge/config.py](src/mcp_llm_bridge/config.py)
 
 ```python
 config = BridgeConfig(


### PR DESCRIPTION
Added as wasn't clear where you were meant to add this config as the previous config was in the .env